### PR TITLE
Fix for joining existing voting sessions and some general clean-up

### DIFF
--- a/public/MainCtrl.js
+++ b/public/MainCtrl.js
@@ -1,8 +1,7 @@
 angular.module('MainCtrl', [])
-.controller('MainController', function($scope, Main, $interval, $location, $timeout) {
+.controller('MainController', function($scope, Main, $interval, $location) {
 
-  // Voter object set up:
-  $scope.dcydrObj = { 
+  var dcydrObjDefaults = { 
     stateView: 1,
     yes: 0,
     no: 0,
@@ -10,6 +9,9 @@ angular.module('MainCtrl', [])
     allVotesIn: false,
     result: null
   };
+
+  // Voter object default initial set up:
+  $scope.dcydrObj = dcydrObjDefaults;
 
   //Set number of voters to a default of 3.  
   $scope.voters = 3;
@@ -23,48 +25,24 @@ angular.module('MainCtrl', [])
     // Update the voter object to reflect the new data
     $scope.dcydrObj = data;
     // Change the route as appropriate
-    $scope.updateView(data.stateView);
+    Main.updateView(data.stateView);
     // This line seems to be needed to make sure all clients update appropriately:
     $scope.$apply();
   });
 
-  // Object to convert the raw stateView number to the appropriate route
-  $scope.viewToRouteConverter = {
-    1: '/view1',
-    2: '/view2a',
-    3: '/view3'
-  };
-
-  // When we need to update the view
-  $scope.updateView = function(stateView) {
-    // Get the route from the route converter object
-    var rerouteTo = $scope.viewToRouteConverter[stateView];
-    // Set the location to be this route
-    $location.path(rerouteTo);
-  };
-
-
-  //Reset stateView - visible on views 2a - 3
+  //Reset stateView - visible on views 2 and 3
   $scope.reset = function() {
     //Confirm pop-up
     if (confirm('Are you sure you want to reset?')) {
       //Reset number of voters to 3 (default)
       $scope.voters = 3;
       //Reset dcydr object to 
-      $scope.dcydrObj = { 
-        // voters: $scope.voters,
-        stateView: 1,
-        yes: 0,
-        no: 0,
-        totalVotes: $scope.voters,
-        allVotesIn: false,
-        result: null
-      };
+      $scope.dcydrObj = dcydrObjDefaults;
       //API call to reset state on server
       Main.resetState()
       .then(
         //Reset view to view1
-        $scope.updateView(1)
+        Main.updateView(1)
       );
     }
   };
@@ -98,10 +76,9 @@ angular.module('MainCtrl', [])
       });
   };
 
-//---view2a------------------------------------------------------
+//---view2------------------------------------------------------
 
   //Take user vote input and post to server - called when user clicks Y/N on view2a.html
-  //Clicking Y or N has href to view 2b?
   $scope.postVoteYes = function() {
     $scope.userVote = 'yes';
     Main.addVoteYes().
@@ -117,18 +94,4 @@ angular.module('MainCtrl', [])
         console.log(err);
       }).then($location.path('/view3'));
   };
-
-//---view2b------------------------------------------------------
-
-  //$scope.userVote should be set in view2a to Yes or No. 
-
-  //Listener for server for result is in $scope.listenToServer function.  When result comes in, view changes to view3
-
-
-//---view3-------------------------------------------------------
-
-  //show $scope.result (var listed above)
-  //Only the reset function/button is available on view3
-
-
 });

--- a/public/MainCtrl.js
+++ b/public/MainCtrl.js
@@ -1,24 +1,21 @@
 angular.module('MainCtrl', [])
 .controller('MainController', function($scope, Main, $interval, $location) {
 
-  var dcydrObjDefaults = { 
+  $scope.dcydrObjDefaults = JSON.stringify({ 
     stateView: 1,
     yes: 0,
     no: 0,
     totalVotes: 3,
     allVotesIn: false,
     result: null
-  };
+  });
 
-  // Voter object default initial set up:
-  $scope.dcydrObj = dcydrObjDefaults;
+  // Voter object default initial set up (copy the object so the two are not connected):
+  $scope.dcydrObj = JSON.parse($scope.dcydrObjDefaults);
 
-  //Set number of voters to a default of 3.  
-  $scope.voters = 3;
   //For displaying user's vote on view3
   $scope.userVote = null;
 
-  //---General functionality for listening to stateView and redirecting upon changes------
   
   //Listen to any server-side stateView changes via the socket, and update $scope.dcydrObj accorgingly
   Main.socket.on('stateViewChange', function(data) {
@@ -30,47 +27,30 @@ angular.module('MainCtrl', [])
     $scope.$apply();
   });
 
-  //Reset stateView - visible on views 2 and 3
-  $scope.reset = function() {
-    //Confirm pop-up
-    if (confirm('Are you sure you want to reset?')) {
-      //Reset number of voters to 3 (default)
-      $scope.voters = 3;
-      //Reset dcydr object to 
-      $scope.dcydrObj = dcydrObjDefaults;
-      //API call to reset state on server
-      Main.resetState()
-      .then(
-        //Reset view to view1
-        Main.updateView(1)
-      );
-    }
-  };
-
 
 //---view1-------------------------------------------------------
 
-  //When '+' is clicked on view1, $scope.voters is changed accordingly  
+  //When '+' is clicked on view1, $scope.dcydrObj.totalVotes is changed accordingly  
   $scope.incNumOfVoters = function() {
     //Set max number of voters to 15 for now.  This may change..
-    if ($scope.voters < 15) {
-      $scope.voters += 1;
+    if ($scope.dcydrObj.totalVotes < 15) {
+      $scope.dcydrObj.totalVotes += 1;
     }
   };
 
-  //When '-' is clicked on view1, $scope.voters is changed accordingly  
+  //When '-' is clicked on view1, $scope.dcydrObj.totalVotes is changed accordingly  
   $scope.decNumOfVoters = function() {
     //Min number of voters is 1 - for now..
-    if ($scope.voters > 1) {
-      $scope.voters -= 1;
+    if ($scope.dcydrObj.totalVotes > 1) {
+      $scope.dcydrObj.totalVotes -= 1;
     }
   };
 
-  //Initiated when user hits 'go'.  take in number of votes from view1.  
+  //Initiated when user hits 'Start!'.  take in number of votes from view1.  
   // Sends POST request to update the server
   // (causes all users views will switch to v2a, handled via sockets)
   $scope.go = function() {
-    Main.startVoting({'votes': $scope.voters}).
+    Main.startVoting({'votes': $scope.dcydrObj.totalVotes}).
       catch(function (err) {
         console.log(err);
       });
@@ -93,5 +73,20 @@ angular.module('MainCtrl', [])
       catch(function (err) {
         console.log(err);
       }).then($location.path('/view3'));
+  };
+
+  //Reset stateView - visible on views 2 and 3
+  $scope.reset = function() {
+    //Confirm pop-up
+    if (confirm('Are you sure you want to reset?')) {
+      //Reset dcydr object to defaults (copy the object so the two are not connected)
+      $scope.dcydrObj = JSON.parse($scope.dcydrObjDefaults);
+      //API call to reset state on server
+      Main.resetState()
+      .then(
+        //Reset view to view1
+        Main.updateView(1)
+      );
+    }
   };
 });

--- a/public/MainService.js
+++ b/public/MainService.js
@@ -1,10 +1,24 @@
 angular.module('MainService', [])
-.factory('Main', ['$http', function($http) {
+.factory('Main', ['$http', '$location', function($http, $location) {
 
   return {
 
     // create the socket variable to be used to emit and listen in the controller
     socket: io('http://localhost:3000'),
+
+    viewToRouteConverter: {
+      1: '/view1',
+      2: '/view2a',
+      3: '/view3'
+    },
+
+    // When we need to update the view
+    updateView: function(stateView) {
+      // Get the route from the route converter object
+      var rerouteTo = this.viewToRouteConverter[stateView];
+      // Set the location to be this route
+      $location.path(rerouteTo);
+    },
 
     //call to get state
     getState: function() {
@@ -34,20 +48,21 @@ angular.module('MainService', [])
       });
     },
 
-
     //Cancel/Reset - not sure if this sends an actual reset vote object, or a message for server to reset the object
     resetState: function() {
       //returns a reset voteData object
       return $http.post('api/vote/reset/');
     },
 
-
-
     // Don't think we need a delete just yet.  But just in case...
     delete: function() {
       return $http.delete('/api/vote/');
     }
-
   };       
+}])
 
-}]);
+.run(function(Main, $location) {
+  Main.getState().then(function (state) {
+    Main.updateView(state.data.stateView);
+  });
+});

--- a/public/views/view1.html
+++ b/public/views/view1.html
@@ -2,7 +2,7 @@
 
   <div id="counter">
     <button class="plus" ng-click="incNumOfVoters()">+</button>
-    <div class="voters">{{ voters }}</div>
+    <div class="voters">{{ dcydrObj.totalVotes }}</div>
     <button class="minus" ng-click="decNumOfVoters()">-</button>
   </div>
 

--- a/public/views/view3.html
+++ b/public/views/view3.html
@@ -1,9 +1,7 @@
 <div class="jumbotron text-center">
 
   <div class="yourVoteHead">You voted</div>
-  <h3 class="yourVote">yes</h3>
-  <!-- <div class="yourVote">{{ userVote }}</div> -->
-
+  <div class="yourVote">{{ userVote }}</div>
 
   <div class="groupVoteHead">The group votes...</div>
   <div class="result">{{ dcydrObj.result }}</div>


### PR DESCRIPTION
Implementing Mario's fix for new users coming into an existing voting session (.run), but reusing fns that were in MainCtrl by moving them to MainService.

Also some general code-cleanup in MainCtrl, such as having everything use the dcydrObj (instead of $scope.voters for example).
